### PR TITLE
Unintended behavior: screaming snake case

### DIFF
--- a/features/casemodes.c
+++ b/features/casemodes.c
@@ -249,7 +249,7 @@ bool process_case_modes(uint16_t keycode, const keyrecord_t *record) {
             }
 
 #ifdef CAPSWORD_USE_SHIFT
-            else if (keycode >= KC_A && keycode <= KC_Z){
+            else if (caps_word_on && keycode >= KC_A && keycode <= KC_Z){
                 tap_code16(LSFT(keycode));
                 return false;
             }


### PR DESCRIPTION
I am just playing around with your code and noticed that I only get the screaming snake case when using `CAPSWORD_USE_SHIFT` with `SNAKECASE`.
Adding `caps_word_on &&` in line 252 fixed the unintended behavior for me.